### PR TITLE
Fixed bug where bot would error on certain users

### DIFF
--- a/modules/whoami.js
+++ b/modules/whoami.js
@@ -7,23 +7,23 @@ const permission = require('../permissions')
 module.exports = {
 	command: 'whoami',
 	handler(bot, args, msg) {
-		let response = `*First Name:* ${msg.from.first_name}\n`
-		response += `*Last Name:* ${msg.from.last_name || "n/a"}\n`
-		response += `*Username* ${msg.from.username || "No username specified."}\n`
-		response += `*ID:* ${msg.from.id}\n`
-		response += `*Permission Level:* ${msg.user.permissionLevel}\n`
+		let response = `<b>First Name:</b> ${msg.from.first_name}\n`
+		response += `<b>Last Name:</b> ${msg.from.last_name || "n/a"}\n`
+		response += `<b>Username:</b> ${msg.from.username || "No username specified."}\n`
+		response += `<b>ID:</b> ${msg.from.id}\n`
+		response += `<b>Permission Level:</b> ${msg.user.permissionLevel}\n`
 
 		if (msg.user.unregistered) {
-			response += 'You are not registered. Try `/register` to get started.'
+			response += 'You are not registered. Try <code>/register</code> to get started.'
 		} else {
 			let user = users[msg.from.id]
-			response += `*Balance:* ${user.balance}\n`
-			response += `_You ${user.banned?'are':'are not'} banned._`
+			response += `<b>Balance:</b> ${user.balance}\n`
+			response += `<i>You ${user.banned?'are':'are not'} banned.</i>`
 		}
 
 		logger.transaction(msg.from.id, 'ran whoami')
 
-		bot.sendMessage(msg.chat.id, response, {parse_mode: "Markdown"})
+		bot.sendMessage(msg.chat.id, response, {parse_mode: "HTML"})
 	},
 	desc: "Sends all the information we have about you.",
 	permission: permission.LEVEL_UNREGISTERED


### PR DESCRIPTION
I found that the bot would error if the username had a "_" in it. I did some poking around the source when I came to the realization that an underscore is a special symbol in markdown. The fix is to replace the markdown with HTML, which prevents this error.
